### PR TITLE
Fix producer work item loop

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -64,7 +64,6 @@ def producer():
         
         # Mark the input item as done
         item.done()
-        break
 
 @task
 def consumer():


### PR DESCRIPTION
## Summary
- fix producer to process all input items instead of stopping after the first

## Testing
- `python -m py_compile tasks.py scripts/*.py`
- `RC_WORKITEM_INPUT_PATH=devdata/work-items-in/input.json ORG_NAME=robocorp python -m robocorp.tasks run tasks.py -t producer`
- `SHARD_ID=1 RC_WORKITEM_INPUT_PATH=devdata/work-items-in/shard-input/work-items.json python -m robocorp.tasks run tasks.py -t consumer`


------
https://chatgpt.com/codex/tasks/task_e_684042f7ef60832ab02831f714c62ec1