### PR TITLE
Fix matrix parsing in workflow

### DIFF
--- a/.github/workflows/fetch-repos-matrix.yaml
+++ b/.github/workflows/fetch-repos-matrix.yaml
@@ -73,7 +73,7 @@ jobs:
     needs: producer
     if: needs.producer.outputs.shard_count > 0
     strategy:
-      matrix: ${{ fromJson(needs.producer.outputs.matrix).matrix }}
+      matrix: ${{ fromJSON(needs.producer.outputs.matrix).matrix }}
       max-parallel: ${{ fromJSON(inputs.max_workers) }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- parse the producer matrix using the GitHub Actions `fromJSON` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684044f343d4832ab53ff9c4ea03f582