### PR TITLE
Fix workflow input dir path

### DIFF
--- a/.github/workflows/fetch-robocorp.yaml
+++ b/.github/workflows/fetch-robocorp.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate input work item for producer
         run: |
-          mkdir -p devdata/work-items-in/test-input-for-producer
+          mkdir -p devdata/work-items-in/input-for-producer
           echo '[{"payload": {"org": "${{ inputs.org_name }}"}}]' > devdata/work-items-in/input-for-producer/work-items.json
 
       - name: Run RCC Producer


### PR DESCRIPTION
## Summary
- fix producer setup path in fetch-robocorp workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840459d1af0832a9a8cf873f8801c9b