### PR TITLE
Improve local sharding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ author: Joshua Yorko, [@joshyorko](https://github.com/joshyorko), joshua.yorko@g
 
 2. **Run the Pipeline:**
    ```bash
-   ./start.sh
+   ./start.sh [MAX_WORKERS]
    ```
-   This will:
-   - Run the producer task
-   - Generate shards and matrix
-   - Run the consumer task
+   - `MAX_WORKERS` (optional) sets how many shards to create. Defaults to `3`.
+   - Set `ORG_NAME` before running if you want to override the organization used
+     for the producer.
+
+   The script now runs the consumer once for each shard so you can test the
+   sharding workflow locally.
 
 3. **Custom Execution:**
    - You can run individual tasks using RCC or Python as defined in `robot.yaml`.

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,39 @@
 #!/bin/bash
+set -euo pipefail
 
+# Number of parallel workers (shards) can be supplied as the first argument.
+# Defaults to 3 if not provided.
+MAX_WORKERS="${1:-3}"
+
+# Optional organization name can be provided via the ORG_NAME environment
+# variable. It falls back to the value defined in the producer environment file.
+
+mkdir -p devdata/work-items-in/input-for-producer
+if [ -n "${ORG_NAME:-}" ]; then
+  echo "[{\"payload\": {\"org\": \"${ORG_NAME}\"}}]" > \
+    devdata/work-items-in/input-for-producer/work-items.json
+fi
+
+# Run producer step
 rcc run -t producer -e devdata/env-for-producer.json
-python3 scripts/generate_shards_and_matrix.py 3
-rcc run -t consumer -e devdata/env-for-consumer.json
+
+# Generate shards based on the desired worker count
+python3 scripts/generate_shards_and_matrix.py "$MAX_WORKERS"
+
+# Iterate over generated shard files and run the consumer for each shard.
+for SHARD_PATH in output/shards/work-items-shard-*.json; do
+  [ -e "$SHARD_PATH" ] || continue
+  SHARD_ID="$(basename "$SHARD_PATH" | grep -oE '[0-9]+')"
+
+  cat > devdata/env-for-consumer.json <<EOF
+{
+  "RC_WORKITEM_ADAPTER": "FileAdapter",
+  "RC_WORKITEM_INPUT_PATH": "$SHARD_PATH",
+  "RC_WORKITEM_OUTPUT_PATH": "output/consumer-to-reporter/work-items-${SHARD_ID}.json"
+}
+EOF
+
+  echo "Running consumer for shard ${SHARD_ID} using ${SHARD_PATH}"
+  SHARD_ID="$SHARD_ID" rcc run -t consumer -e devdata/env-for-consumer.json
+done
 


### PR DESCRIPTION
## Summary
- run the consumer once for each shard in `start.sh`
- document how to use the updated script for local testing

## Testing
- `python3 -m py_compile tasks.py scripts/*.py`
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_684046fdb194832a81cb9435bfdc9eba