### PR TITLE
Fix .gitignore duplicate entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ devdata/work-items-out/
 testrun/*
 .~lock*
 *.pkl
-output/
 .venv/


### PR DESCRIPTION
## Summary
- remove duplicate `output/` entry from `.gitignore`
- ensure `.gitignore` has a trailing newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404a44aedc832a90df5336fa185235