### PR TITLE
Fix start script work item creation

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,12 @@ mkdir -p devdata/work-items-in/input-for-producer
 if [ -n "${ORG_NAME:-}" ]; then
   echo "[{\"payload\": {\"org\": \"${ORG_NAME}\"}}]" > \
     devdata/work-items-in/input-for-producer/work-items.json
+else
+  # Create a default work item when ORG_NAME isn't provided.
+  # The organization will then be read from env-for-producer.json
+  # by the producer task.
+  echo "[{\"payload\": {}}]" > \
+    devdata/work-items-in/input-for-producer/work-items.json
 fi
 
 # Run producer step


### PR DESCRIPTION
## Summary
- ensure `start.sh` always creates an input work item

## Testing
- `bash -n start.sh`
- `python -m py_compile tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_6854a88d6f44832a9e4346f1817333dc